### PR TITLE
Add resource names to chart file names to prevent collision

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -108,7 +108,7 @@ func objectToTemplate(objects *[]runtime.RawExtension, templates *[]*chart.File)
 		if err != nil {
 			return fmt.Errorf(fmt.Sprintf("Failed to unmarshal Raw resource\n%v\n", v.Raw) + err.Error())
 		}
-		name := "templates/" + strings.ToLower(k8sR.GetKind()+".yaml")
+		name := "templates/" + strings.ToLower(k8sR.GetKind()+"-"+k8sR.GetName()+".yaml")
 
 		log.Printf("Creating a template for object %s", name)
 		data, err := yaml.JSONToYAML(v.Raw)


### PR DESCRIPTION
A fix for Issue #4 that adds the name of each resource to the corresponding template in the chart, in order to allow multiple resources of a single kind to coexist in a single chart.